### PR TITLE
Chore: Create navigations enhacement

### DIFF
--- a/bin/create/component/functions/create-component.js
+++ b/bin/create/component/functions/create-component.js
@@ -13,11 +13,17 @@ const {
  * @param {boolean} ts - write file in typescript.
  * @param {string} folder - folder path to create files within.
  * @param {string} template - template file to create component with.
+ * @param {boolean} overwrite - overwrite existed files.
  * @author [Omar Belghaouti](https://github.com/Omar-Belghaouti)
  */
-exports.createComponent = (componentName, js, ts, folder, template) => {
-  // TODO: apply regex to component name
-  // TODO: write files synchronously
+exports.createComponent = (
+  componentName,
+  js,
+  ts,
+  folder,
+  template,
+  overwrite
+) => {
   let component =
     componentName.charAt(0).toUpperCase() + componentName.slice(1);
   if (componentName.includes("-")) {
@@ -37,7 +43,7 @@ exports.createComponent = (componentName, js, ts, folder, template) => {
         ? `src/components/${componentName.toLowerCase()}/styles.ts`
         : `src/components/${folder}/${componentName.toLowerCase()}/styles.ts`;
 
-    if (fs.existsSync(path)) {
+    if (fs.existsSync(path) && !overwrite) {
       console.log(`${path} already exist`);
     } else {
       // check if template file exist
@@ -93,7 +99,7 @@ exports.createComponent = (componentName, js, ts, folder, template) => {
       folder === ""
         ? `src/components/${componentName.toLowerCase()}/styles.js`
         : `src/components/${folder}/${componentName.toLowerCase()}/styles.js`;
-    if (fs.existsSync(path)) {
+    if (fs.existsSync(path) && !overwrite) {
       console.log(`${path} already exist`);
     } else {
       // check if template file exist

--- a/bin/create/navigation/functions/create-navigation.js
+++ b/bin/create/navigation/functions/create-navigation.js
@@ -8,16 +8,17 @@ const { navigationTemplateJs, navigationTemplateTs } = require("../templates");
  * @param {boolean} js - write file in javascript.
  * @param {boolean} ts - write file in typescript.
  * @param {string} folder - folder path to create navigation with.
+ * @param {boolean} overwrite - overwrite existed files.
  * @author [Omar Belghaouti](https://github.com/Omar-Belghaouti)
  */
-exports.createNavigation = (navigation, js, ts, folder) => {
+exports.createNavigation = (navigation, js, ts, folder, overwrite) => {
   const path = folder === "" ? "src/screens/" : `src/screens/${folder}/`;
   switch (navigation[0].toLowerCase()) {
     case "stack":
     case "drawer":
     case "tab": {
       if (ts) {
-        if (fs.existsSync(`${path}navigation.tsx`)) {
+        if (fs.existsSync(`${path}navigation.tsx`) && !overwrite) {
           console.log(`${path}navigation.tsx already exist`);
           break;
         }
@@ -106,7 +107,7 @@ exports.createNavigation = (navigation, js, ts, folder) => {
           );
         }
       } else {
-        if (fs.existsSync(`${path}navigation.jsx`)) {
+        if (fs.existsSync(`${path}navigation.jsx`) && !overwrite) {
           console.log(`${path}navigation.jsx already exist`);
           break;
         }

--- a/bin/create/navigation/functions/create-navigation.js
+++ b/bin/create/navigation/functions/create-navigation.js
@@ -49,18 +49,40 @@ exports.createNavigation = (navigation, js, ts, folder) => {
                 importAs: true,
               });
             } else {
+              // folders and files
+              let faf = fs.readdirSync(`${_path}`);
+              let importableAs = faf.some((el) => el === "navigation.tsx");
               const __path = `./${_path}`.replace("src/screens/", "");
-              existedScreens.push({
-                folderName: screen,
-                componentName: `${componentName}Screen`,
-                path:
-                  folder === ""
-                    ? __path.slice(0, __path.length - 1)
-                    : __path
-                        .slice(0, __path.length - 1)
-                        .replace(`${folder}/`, ""),
-                importAs: false,
-              });
+              if (importableAs) {
+                existedScreens.push({
+                  folderName: screen,
+                  componentName: `${componentName}Screen`,
+                  path:
+                    folder === ""
+                      ? __path.slice(0, __path.length - 1)
+                      : __path
+                          .slice(0, __path.length - 1)
+                          .replace(`${folder}/`, ""),
+                  importAs: importableAs,
+                });
+              } else {
+                let importable = faf.some((el) => el === "index.tsx");
+                if (importable) {
+                  existedScreens.push({
+                    folderName: screen,
+                    componentName: `${componentName}Screen`,
+                    path:
+                      folder === ""
+                        ? __path.slice(0, __path.length - 1)
+                        : __path
+                            .slice(0, __path.length - 1)
+                            .replace(`${folder}/`, ""),
+                    importAs: importableAs,
+                  });
+                } else {
+                  console.log(`${_path}navigation.tsx does not exist`);
+                }
+              }
             }
           } else {
             console.log(`${_path} does not exist`);
@@ -116,18 +138,40 @@ exports.createNavigation = (navigation, js, ts, folder) => {
                 importAs: true,
               });
             } else {
+              // folders and files
+              let faf = fs.readdirSync(`${_path}`);
+              let importableAs = faf.some((el) => el === "navigation.jsx");
               const __path = `./${_path}`.replace("src/screens/", "");
-              existedScreens.push({
-                folderName: screen,
-                componentName: `${componentName}Screen`,
-                path:
-                  folder === ""
-                    ? __path.slice(0, __path.length - 1)
-                    : __path
-                        .slice(0, __path.length - 1)
-                        .replace(`${folder}/`, ""),
-                importAs: false,
-              });
+              if (importableAs) {
+                existedScreens.push({
+                  folderName: screen,
+                  componentName,
+                  path:
+                    folder === ""
+                      ? __path.slice(0, __path.length - 1)
+                      : __path
+                          .slice(0, __path.length - 1)
+                          .replace(`${folder}/`, ""),
+                  importAs: importableAs,
+                });
+              } else {
+                let importable = faf.some((el) => el === "index.jsx");
+                if (importable) {
+                  existedScreens.push({
+                    folderName: screen,
+                    componentName: `${componentName}Screen`,
+                    path:
+                      folder === ""
+                        ? __path.slice(0, __path.length - 1)
+                        : __path
+                            .slice(0, __path.length - 1)
+                            .replace(`${folder}/`, ""),
+                    importAs: importableAs,
+                  });
+                } else {
+                  console.log(`${_path}navigation.jsx does not exist`);
+                }
+              }
             }
           } else {
             console.log(`${_path} does not exist`);

--- a/bin/create/navigation/functions/create-navigation.js
+++ b/bin/create/navigation/functions/create-navigation.js
@@ -13,6 +13,10 @@ const { navigationTemplateJs, navigationTemplateTs } = require("../templates");
  */
 exports.createNavigation = (navigation, js, ts, folder, overwrite) => {
   const path = folder === "" ? "src/screens/" : `src/screens/${folder}/`;
+  if (!fs.existsSync(path)) {
+    console.log(`${path} does not exist`);
+    return;
+  }
   switch (navigation[0].toLowerCase()) {
     case "stack":
     case "drawer":
@@ -23,9 +27,15 @@ exports.createNavigation = (navigation, js, ts, folder, overwrite) => {
           break;
         }
         // get existed screens
+        navigation.shift();
+        let screens = navigation;
         let existedScreens = [];
-        for (let i = 1; i < navigation.length; i++) {
-          const screen = navigation[i];
+        if (screens[0] === "*") {
+          // folders and files
+          screens = fs.readdirSync(path).filter((el) => !el.endsWith("sx"));
+        }
+        for (let i = 0; i < screens.length; i++) {
+          const screen = screens[i];
           let componentName = screen.charAt(0).toUpperCase() + screen.slice(1);
           if (screen.includes("-")) {
             componentName = "";
@@ -112,9 +122,15 @@ exports.createNavigation = (navigation, js, ts, folder, overwrite) => {
           break;
         }
         // get existed screens
+        navigation.shift();
+        let screens = navigation;
         let existedScreens = [];
-        for (let i = 1; i < navigation.length; i++) {
-          const screen = navigation[i];
+        if (screens[0] === "*") {
+          // folders and files
+          screens = fs.readdirSync(path).filter((el) => !el.endsWith("sx"));
+        }
+        for (let i = 0; i < screens.length; i++) {
+          const screen = screens[i];
           let componentName = screen.charAt(0).toUpperCase() + screen.slice(1);
           if (screen.includes("-")) {
             componentName = "";

--- a/bin/create/redux/functions/create-redux-store.js
+++ b/bin/create/redux/functions/create-redux-store.js
@@ -14,11 +14,12 @@ const {
  * @description this function is used to create redux store file.
  * @param {boolean} js - write file in javascript.
  * @param {boolean} ts - write file in typescript.
+ * @param {boolean} overwrite - overwrite existed files.
  * @author [Omar Belghaouti](https://github.com/Omar-Belghaouti)
  */
-exports.createReduxStore = (js, ts) => {
+exports.createReduxStore = (js, ts, overwrite) => {
   const path = "src/redux/";
-  if (fs.existsSync(path)) {
+  if (fs.existsSync(path) && !overwrite) {
     console.log("Redux implementation already exists");
   } else {
     if (ts) {

--- a/bin/create/screen/functions/create-screen.js
+++ b/bin/create/screen/functions/create-screen.js
@@ -15,11 +15,10 @@ const {
  * @param {boolean} ts - write file in typescript.
  * @param {string} folder - folder path to create files within.
  * @param {string} template - template file to create screen with.
+ * @param {boolean} overwrite - overwrite existed files.
  * @author [Omar Belghaouti](https://github.com/Omar-Belghaouti)
  */
-exports.createScreen = (screenName, js, ts, folder, template) => {
-  // TODO: apply regex to screen name
-  // TODO: write files synchronously
+exports.createScreen = (screenName, js, ts, folder, template, overwrite) => {
   let screen = screenName.charAt(0).toUpperCase() + screenName.slice(1);
   if (screenName.includes("-")) {
     screen = "";
@@ -32,7 +31,7 @@ exports.createScreen = (screenName, js, ts, folder, template) => {
     folder === ""
       ? `src/screens/${screenName.toLowerCase()}/`
       : `src/screens/${folder}/${screenName.toLowerCase()}/`;
-  if (fs.existsSync(path)) {
+  if (fs.existsSync(path) && !overwrite) {
     console.log(`${path} already exist`);
   } else {
     if (ts) {

--- a/bin/index.js
+++ b/bin/index.js
@@ -67,12 +67,27 @@ yargs
           type: "string",
           default: "",
           describe: "Template to be used to create files with",
+        })
+        .option("o", {
+          alias: "overwrite",
+          type: "boolean",
+          default: false,
+          describe: "Used to overwrite created files",
         });
     },
     (argv) => {
       if (fs.existsSync("package.json")) {
-        let { component, screen, redux, navigation, js, ts, folder, template } =
-          argv;
+        let {
+          component,
+          screen,
+          redux,
+          navigation,
+          js,
+          ts,
+          folder,
+          template,
+          overwrite,
+        } = argv;
         // check if project is written in typescript
         let faf = fs.readdirSync("."); // folders and files
         for (let i = 0; i < faf.length; i++) {
@@ -83,15 +98,17 @@ yargs
         }
         if (component) {
           component.forEach((c) =>
-            createComponent(c, js, ts, folder, template)
+            createComponent(c, js, ts, folder, template, overwrite)
           );
         } else if (screen) {
-          screen.forEach((s) => createScreen(s, js, ts, folder, template));
+          screen.forEach((s) =>
+            createScreen(s, js, ts, folder, template, overwrite)
+          );
         } else if (redux) {
-          createReduxStore(js, ts);
+          createReduxStore(js, ts, overwrite);
         } else if (navigation) {
           if (navigation.length > 2) {
-            createNavigation(navigation, js, ts, folder);
+            createNavigation(navigation, js, ts, folder, overwrite);
           } else {
             console.log("At least give 2 screens");
           }

--- a/bin/index.js
+++ b/bin/index.js
@@ -107,11 +107,7 @@ yargs
         } else if (redux) {
           createReduxStore(js, ts, overwrite);
         } else if (navigation) {
-          if (navigation.length > 2) {
-            createNavigation(navigation, js, ts, folder, overwrite);
-          } else {
-            console.log("At least give 2 screens");
-          }
+          createNavigation(navigation, js, ts, folder, overwrite);
         } else {
           console.log("Check usage: rnhc create --help");
         }


### PR DESCRIPTION
This PR is dedicated to enhance the creation of navigation files.

# TODOs:
- [x] import nested navigations enhancement (import only those with navigation file).
- [x] add overwrite to overwrite the creation of navigation files (useful when updating navigation files).
## Example:
At first you have only `s1` and `s2` screens.
```sh
rnhc create -n stack s1 s2
```
Later on you want to add `s3` screen or even you may delete one of the above screens and you want to update the navigation file by doing this:
```sh
rnhc create -n stack s1 s2 s3 --overwrite
```
This will override the default behavior that does not create already existed navigation files, but instead it will overwrite the existed file with the new screens.

This is also applicable for nested navigations.

- [x]  take wildcard in the command (`*`) as an input for many screens that exists on that folder.
## Example:
Sometimes you may have ten or more screens and you don't want to write each screen's name, so you can just run:
```sh
rnhc create -n stack *
```
This is also applicable for nested screens like this:
```sh
rnhc create -n stack * -f path/to/folder
```

