### PR TITLE
Fix: changing wildcard `*` to use an empty string instead

### DIFF
--- a/bin/create/navigation/functions/create-navigation.js
+++ b/bin/create/navigation/functions/create-navigation.js
@@ -19,7 +19,15 @@ exports.createNavigation = (navigation, js, ts, folder, overwrite) => {
     console.log(`${path} does not exist`);
     return;
   }
-  switch (navigation[0].toLowerCase()) {
+  if (!navigation.length) {
+    console.log("Please provide at least a navigation type");
+    console.log(
+      "Only the following navigations are supported: stack, drawer or tab"
+    );
+    return;
+  }
+  const navigationType = navigation[0].toLowerCase();
+  switch (navigationType) {
     case "stack":
     case "drawer":
     case "tab": {
@@ -32,7 +40,7 @@ exports.createNavigation = (navigation, js, ts, folder, overwrite) => {
         navigation.shift();
         let screens = navigation;
         let existedScreens = [];
-        if (screens[0] === "*") {
+        if (screens.length === 0) {
           // folders and files
           screens = fs.readdirSync(path).filter((el) => !el.endsWith("sx"));
         }
@@ -63,7 +71,7 @@ exports.createNavigation = (navigation, js, ts, folder, overwrite) => {
               });
             } else {
               // folders and files
-              let faf = fs.readdirSync(`${_path}`);
+              let faf = fs.readdirSync(_path);
               let importableAs = faf.some((el) => el === "navigation.tsx");
               const __path = `./${_path}`.replace(`${screensRoot}/`, "");
               if (importableAs) {
@@ -109,7 +117,7 @@ exports.createNavigation = (navigation, js, ts, folder, overwrite) => {
           fs.writeFile(
             `${path}navigation.tsx`,
             navigationTemplateTs(
-              navigation[0].toLowerCase(),
+              navigationType,
               existedScreens,
               defaultExports
             ),
@@ -131,7 +139,7 @@ exports.createNavigation = (navigation, js, ts, folder, overwrite) => {
         navigation.shift();
         let screens = navigation;
         let existedScreens = [];
-        if (screens[0] === "*") {
+        if (screens.length === 0) {
           // folders and files
           screens = fs.readdirSync(path).filter((el) => !el.endsWith("sx"));
         }
@@ -208,7 +216,7 @@ exports.createNavigation = (navigation, js, ts, folder, overwrite) => {
           fs.writeFile(
             `${path}navigation.jsx`,
             navigationTemplateJs(
-              navigation[0].toLowerCase(),
+              navigationType,
               existedScreens,
               defaultExports
             ),

--- a/docs/CREATING_FILES.md
+++ b/docs/CREATING_FILES.md
@@ -466,7 +466,7 @@ export const Navigation = () => {
 4. To create a navigation file for multiple screens that resides at the root of the `src/screens/` folder, you can run this:
 
 ```sh
-rnhc create -n <navigation-type> *
+rnhc create -n <navigation-type>
 ```
 
 - This will create the navigation file for all existed screens in the `src/screens/` folder.
@@ -474,12 +474,12 @@ rnhc create -n <navigation-type> *
 You can also run this command to create a navigation file for multiple screens that resides in a specific path under the `src/screens/` folder:
 
 ```sh
-rnhc create -n <navigation-type> * -f <folder-path>
+rnhc create -n <navigation-type> -f <folder-path>
 ```
 
 - This will create the navigation file for all existed screens in the `src/screens/<folder-path>/` folder.
 
-- The wildcard `*` can work also for the nested navigations.
+- This also work for the nested navigations.
 
 - All the sub folders should contain the navigation files so it can be added to the navigation file you want to create, for example take this structure:
 
@@ -522,7 +522,7 @@ src
 When you try to create a navigation like this:
 
 ```sh
-rnhc create -n stack *
+rnhc create -n stack
 ```
 
 It will contain only `screen-three` and `screen-four` because the `src/screens/folder` does not contain a navigation file.
@@ -532,7 +532,7 @@ So if you want to create a navigation file for all existed screens in the `src/s
 By updating it means overwriting in other words, so you can just do this:
 
 ```sh
-rnhc create -n stack * -o
+rnhc create -n stack -o
 ```
 
 ## Templates

--- a/docs/NOTES.md
+++ b/docs/NOTES.md
@@ -57,7 +57,7 @@ rnhc create --action test-reducer test-action -o
 - This is helpful when you want to update your navigation files, for example you already have a navigation file in `src/screens/` folder and you want to update it with the new screens you created:
 
 ```sh
-rnhc create -n stack * --overwrite
+rnhc create -n stack --overwrite
 ```
 
 - When creating reducers you should have already a redux implmentation created with `rnhc create -r` so it can work.


### PR DESCRIPTION
This PR is dedicated to fix the issue #11 because the `*` is a special character reserved for the os and `yargs` interpret it as to read the current directory.