### PR TITLE
Chore: Get Kebab case for any given string

### DIFF
--- a/bin/combine/component/combine-components.js
+++ b/bin/combine/component/combine-components.js
@@ -1,5 +1,5 @@
 const fs = require("file-system");
-const { config } = require("../../utils");
+const { config, getKebabCase } = require("../../utils");
 
 /**
  * @function combineComponents
@@ -10,6 +10,13 @@ const { config } = require("../../utils");
  */
 exports.combineComponents = (components, folder) => {
   const { componentsRoot } = config;
+  components = components.map((component) => getKebabCase(component));
+  folder = folder.includes("/")
+    ? folder
+        .split("/")
+        .map((folder) => getKebabCase(folder))
+        .join("/")
+    : getKebabCase(folder);
   const path = `${componentsRoot}/`;
   const _path = `${path}${folder}/`;
   let folders = [];

--- a/bin/combine/screen/combine-screens.js
+++ b/bin/combine/screen/combine-screens.js
@@ -1,5 +1,5 @@
 const fs = require("file-system");
-const { config } = require("../../utils");
+const { config, getKebabCase } = require("../../utils");
 
 /**
  * @function combineScreens
@@ -10,6 +10,13 @@ const { config } = require("../../utils");
  */
 exports.combineScreens = (screens, folder) => {
   const { screensRoot } = config;
+  screens = screens.map((screen) => getKebabCase(screen));
+  folder = folder.includes("/")
+    ? folder
+        .split("/")
+        .map((folder) => getKebabCase(folder))
+        .join("/")
+    : getKebabCase(folder);
   const path = `${screensRoot}/`;
   const _path = `${path}${folder}/`;
   let folders = [];

--- a/bin/create/component/functions/create-component.js
+++ b/bin/create/component/functions/create-component.js
@@ -4,7 +4,7 @@ const {
   componentTemplateTs,
   stylesTemplate,
 } = require("../templates");
-const { config, getComponentName } = require("../../../utils");
+const { config, getComponentName, getKebabCase } = require("../../../utils");
 
 /**
  * @function createComponent
@@ -26,16 +26,23 @@ exports.createComponent = (
   overwrite
 ) => {
   const { withStyles, withProps, defaultExports, componentsRoot } = config;
+  componentName = getKebabCase(componentName);
+  folder = folder.includes("/")
+    ? folder
+        .split("/")
+        .map((folder) => getKebabCase(folder))
+        .join("/")
+    : getKebabCase(folder);
   let component = getComponentName(componentName);
   if (ts) {
     const path =
       folder === ""
-        ? `${componentsRoot}/${componentName.toLowerCase()}/index.tsx`
-        : `${componentsRoot}/${folder}/${componentName.toLowerCase()}/index.tsx`;
+        ? `${componentsRoot}/${componentName}/index.tsx`
+        : `${componentsRoot}/${folder}/${componentName}/index.tsx`;
     const stylesPath =
       folder === ""
-        ? `${componentsRoot}/${componentName.toLowerCase()}/styles.ts`
-        : `${componentsRoot}/${folder}/${componentName.toLowerCase()}/styles.ts`;
+        ? `${componentsRoot}/${componentName}/styles.ts`
+        : `${componentsRoot}/${folder}/${componentName}/styles.ts`;
 
     if (fs.existsSync(path) && !overwrite) {
       console.log(`${path} already exist`);
@@ -97,12 +104,12 @@ exports.createComponent = (
   } else {
     const path =
       folder === ""
-        ? `${componentsRoot}/${componentName.toLowerCase()}/index.jsx`
-        : `${componentsRoot}/${folder}/${componentName.toLowerCase()}/index.jsx`;
+        ? `${componentsRoot}/${componentName}/index.jsx`
+        : `${componentsRoot}/${folder}/${componentName}/index.jsx`;
     const stylesPath =
       folder === ""
-        ? `${componentsRoot}/${componentName.toLowerCase()}/styles.js`
-        : `${componentsRoot}/${folder}/${componentName.toLowerCase()}/styles.js`;
+        ? `${componentsRoot}/${componentName}/styles.js`
+        : `${componentsRoot}/${folder}/${componentName}/styles.js`;
     if (fs.existsSync(path) && !overwrite) {
       console.log(`${path} already exist`);
     } else {

--- a/bin/create/navigation/functions/create-navigation.js
+++ b/bin/create/navigation/functions/create-navigation.js
@@ -1,6 +1,6 @@
 const fs = require("file-system");
 const { navigationTemplateJs, navigationTemplateTs } = require("../templates");
-const { config } = require("../../../utils");
+const { config, getKebabCase } = require("../../../utils");
 
 /**
  * @function createNavigation
@@ -14,6 +14,12 @@ const { config } = require("../../../utils");
  */
 exports.createNavigation = (navigation, js, ts, folder, overwrite) => {
   const { defaultExports, screensRoot } = config;
+  folder = folder.includes("/")
+    ? folder
+        .split("/")
+        .map((folder) => getKebabCase(folder))
+        .join("/")
+    : getKebabCase(folder);
   const path = folder === "" ? `${screensRoot}/` : `${screensRoot}/${folder}/`;
   if (!fs.existsSync(path)) {
     console.log(`${path} does not exist`);
@@ -39,6 +45,7 @@ exports.createNavigation = (navigation, js, ts, folder, overwrite) => {
         // get existed screens
         navigation.shift();
         let screens = navigation;
+        screens = screens.map((screen) => getKebabCase(screen));
         let existedScreens = [];
         if (screens.length === 0) {
           // folders and files

--- a/bin/create/redux/functions/create-action.js
+++ b/bin/create/redux/functions/create-action.js
@@ -1,5 +1,5 @@
 const fs = require("file-system");
-const { config, getCamelCase } = require("../../../utils");
+const { config, getCamelCase, getKebabCase } = require("../../../utils");
 const {
   customActionTemplateJs,
   customActionTemplateTs,
@@ -24,7 +24,7 @@ exports.createAction = (actionName, js, ts, overwrite) => {
     console.log(`${reduxRoot} does not exist`);
     return;
   }
-  const reducer = actionName[0];
+  const reducer = getKebabCase(actionName[0]);
   const reducerPath = `${reduxRoot}/reducers/${reducer}`;
   if (!fs.existsSync(reducerPath)) {
     console.log(`${reducerPath} does not exist`);
@@ -41,7 +41,7 @@ exports.createAction = (actionName, js, ts, overwrite) => {
     fs.fs.mkdirSync(actionsPath);
   }
   for (let i = 0; i < actions.length; i++) {
-    const action = actions[i];
+    const action = getKebabCase(actions[i]);
     const actionFilePath = `${actionsPath}/${action}.${fileExtension}`;
     // create action
     if (fs.existsSync(actionFilePath) && !overwrite) {

--- a/bin/create/redux/functions/create-reducer.js
+++ b/bin/create/redux/functions/create-reducer.js
@@ -1,5 +1,5 @@
 const fs = require("file-system");
-const { config, getCamelCase } = require("../../../utils");
+const { config, getCamelCase, getKebabCase } = require("../../../utils");
 const {
   customReducerTemplateTs,
   customReducerTemplateJs,
@@ -19,6 +19,7 @@ exports.createReducer = (reducerName, js, ts, overwrite) => {
     console.log("Redux implementation does not exist");
     return;
   }
+  reducerName = getKebabCase(reducerName);
   const path = `${reduxRoot}/reducers/${reducerName}/`;
   let reducer = getCamelCase(reducerName);
   if (fs.existsSync(path) && !overwrite) {

--- a/bin/create/screen/functions/create-screen.js
+++ b/bin/create/screen/functions/create-screen.js
@@ -6,7 +6,7 @@ const {
   screenFunctionTemplateTs,
   stylesTemplate,
 } = require("../templates");
-const { config, getComponentName } = require("../../../utils");
+const { config, getComponentName, getKebabCase } = require("../../../utils");
 
 /**
  * @function createScreen
@@ -22,11 +22,18 @@ const { config, getComponentName } = require("../../../utils");
 exports.createScreen = (screenName, js, ts, folder, template, overwrite) => {
   const { withStyles, withFunctions, withProps, defaultExports, screensRoot } =
     config;
+  screenName = getKebabCase(screenName);
+  folder = folder.includes("/")
+    ? folder
+        .split("/")
+        .map((folder) => getKebabCase(folder))
+        .join("/")
+    : getKebabCase(folder);
   let screen = getComponentName(screenName);
   const path =
     folder === ""
-      ? `${screensRoot}/${screenName.toLowerCase()}/`
-      : `${screensRoot}/${folder}/${screenName.toLowerCase()}/`;
+      ? `${screensRoot}/${screenName}/`
+      : `${screensRoot}/${folder}/${screenName}/`;
   if (fs.existsSync(path) && !overwrite) {
     console.log(`${path} already exist`);
   } else {

--- a/bin/delete/component/delete-components.js
+++ b/bin/delete/component/delete-components.js
@@ -1,5 +1,5 @@
 const fs = require("file-system");
-const { config } = require("../../utils");
+const { config, getKebabCase } = require("../../utils");
 
 /**
  * @function deleteComponents
@@ -10,6 +10,13 @@ const { config } = require("../../utils");
  */
 exports.deleteComponents = (components, folder) => {
   const { componentsRoot } = config;
+  components = components.map((component) => getKebabCase(component));
+  folder = folder.includes("/")
+    ? folder
+        .split("/")
+        .map((folder) => getKebabCase(folder))
+        .join("/")
+    : getKebabCase(folder);
   const path =
     folder === "" ? `${componentsRoot}/` : `${componentsRoot}/${folder}/`;
   if (components.length === 0 && folder !== "") {

--- a/bin/delete/navigation/delete-navigation.js
+++ b/bin/delete/navigation/delete-navigation.js
@@ -1,5 +1,5 @@
 const fs = require("file-system");
-const { config } = require("../../utils");
+const { config, getKebabCase } = require("../../utils");
 
 /**
  * @function deleteNavigation
@@ -8,6 +8,12 @@ const { config } = require("../../utils");
  */
 exports.deleteNavigation = (folder) => {
   const { screensRoot } = config;
+  folder = folder.includes("/")
+    ? folder
+        .split("/")
+        .map((folder) => getKebabCase(folder))
+        .join("/")
+    : getKebabCase(folder);
   const path = folder === "" ? `${screensRoot}/` : `${screensRoot}/${folder}/`;
   if (fs.existsSync(`${path}navigation.tsx`)) {
     fs.unlink(`${path}navigation.tsx`, (err) => {

--- a/bin/delete/redux/delete-actions.js
+++ b/bin/delete/redux/delete-actions.js
@@ -1,5 +1,5 @@
 const fs = require("file-system");
-const { config, getCamelCase } = require("../../utils");
+const { config, getCamelCase, getKebabCase } = require("../../utils");
 
 /**
  * @function deleteActions
@@ -24,7 +24,7 @@ exports.deleteActions = (actions, ts) => {
     encoding: "utf8",
   });
   let storeResult = storeIndexFileContent;
-  let reducer = actions[0];
+  let reducer = getKebabCase(actions[0]);
   const path = `${reduxRoot}/actions/${reducer}/`;
   if (!fs.existsSync(path)) {
     console.log(`${path} does not exist`);
@@ -50,9 +50,12 @@ exports.deleteActions = (actions, ts) => {
     }
     actions = existedActions;
   }
-  actions = actions.map((a) =>
-    a.endsWith(`.${fileExtension}`) ? a : `${a}.${fileExtension}`
-  );
+  actions = actions.map((a) => {
+    const actionKebabCase = getKebabCase(a.split(".")[0]);
+    return actionKebabCase.endsWith(`.${fileExtension}`)
+      ? actionKebabCase
+      : `${actionKebabCase}.${fileExtension}`;
+  });
   actions.forEach((a) => {
     const _path = `${path}${a}`;
     try {

--- a/bin/delete/redux/delete-reducers.js
+++ b/bin/delete/redux/delete-reducers.js
@@ -1,5 +1,5 @@
 const fs = require("file-system");
-const { config, getCamelCase } = require("../../utils");
+const { config, getCamelCase, getKebabCase } = require("../../utils");
 
 /**
  * @function deleteReducers
@@ -10,6 +10,7 @@ const { config, getCamelCase } = require("../../utils");
  */
 exports.deleteReducers = (reducers, ts) => {
   const { reduxRoot } = config;
+  reducers = reducers.map((reducer) => getKebabCase(reducer));
   const path = `${reduxRoot}/reducers/`;
   const fileExtension = ts ? "ts" : "js";
   const data = fs.readFileSync(`${reduxRoot}/reducers/index.${fileExtension}`, {
@@ -48,7 +49,10 @@ exports.deleteReducers = (reducers, ts) => {
           ),
           ""
         );
-        result = result.replace(new RegExp(`${r}[. \t\n]*,`), "");
+        result = result.replace(
+          new RegExp(`[. \t]*${getCamelCase(r)}[. \t]*,`),
+          ""
+        );
       }
       console.log(`${_path} deleted`);
     } catch (err) {

--- a/bin/delete/screen/delete-screens.js
+++ b/bin/delete/screen/delete-screens.js
@@ -1,5 +1,5 @@
 const fs = require("file-system");
-const { config } = require("../../utils");
+const { config, getKebabCase } = require("../../utils");
 
 /**
  * @function deleteScreens
@@ -10,6 +10,13 @@ const { config } = require("../../utils");
  */
 exports.deleteScreens = (screens, folder) => {
   const { screensRoot } = config;
+  screens = screens.map((screen) => getKebabCase(screen));
+  folder = folder.includes("/")
+    ? folder
+        .split("/")
+        .map((folder) => getKebabCase(folder))
+        .join("/")
+    : getKebabCase(folder);
   const path = folder === "" ? `${screensRoot}/` : `${screensRoot}/${folder}/`;
   if (screens.length === 0 && folder !== "") {
     try {

--- a/bin/utils/get-kebab-case.js
+++ b/bin/utils/get-kebab-case.js
@@ -1,0 +1,14 @@
+/**
+ * @function getKebabCase
+ * @description Get the kebab case of the string
+ * @param {string} string - string to convert.
+ * @example getKebabCase("CompOne");
+ * @returns {string} "comp-one"
+ * @author [Omar Belghaouti](https://github.com/Omar-Belghaouti)
+ */
+exports.getKebabCase = (string) => {
+  return string
+    .match(/[A-Z]{2,}(?=[A-Z][a-z]+[0-9]*|\b)|[A-Z]?[a-z]+[0-9]*|[A-Z]|[0-9]+/g)
+    .join("-")
+    .toLowerCase();
+};

--- a/bin/utils/get-kebab-case.js
+++ b/bin/utils/get-kebab-case.js
@@ -7,6 +7,13 @@
  * @author [Omar Belghaouti](https://github.com/Omar-Belghaouti)
  */
 exports.getKebabCase = (string) => {
+  if (
+    !/[A-Z]{2,}(?=[A-Z][a-z]+[0-9]*|\b)|[A-Z]?[a-z]+[0-9]*|[A-Z]|[0-9]+/g.test(
+      string
+    )
+  ) {
+    return string.toLowerCase();
+  }
   return string
     .match(/[A-Z]{2,}(?=[A-Z][a-z]+[0-9]*|\b)|[A-Z]?[a-z]+[0-9]*|[A-Z]|[0-9]+/g)
     .join("-")

--- a/bin/utils/index.js
+++ b/bin/utils/index.js
@@ -4,6 +4,7 @@ const { rootChecker } = require("./root-checker");
 const { languageChecker } = require("./language-checker");
 const { getComponentName } = require("./get-component-name");
 const { getCamelCase } = require("./get-reducer-name");
+const { getKebabCase } = require("./get-kebab-case");
 
 exports.config = config;
 exports.loadConfig = loadConfig;
@@ -11,3 +12,4 @@ exports.rootChecker = rootChecker;
 exports.languageChecker = languageChecker;
 exports.getComponentName = getComponentName;
 exports.getCamelCase = getCamelCase;
+exports.getKebabCase = getKebabCase;

--- a/tests/create.spec.js
+++ b/tests/create.spec.js
@@ -271,7 +271,7 @@ describe("create navigation tests", () => {
       createNavigation(["stack", "s1", "s2"], false, true, "", false);
       await sleep(100);
       expect(fs.existsSync("./src/screens/navigation.tsx")).toBe(true);
-      deleteNavigation();
+      deleteNavigation("");
       await sleep(100);
     } catch (err) {
       fail(err);


### PR DESCRIPTION
This PR is for adding a useful utility function to get the kebab case for any given string so the users can enter any type of a string and it will be converted to kebab case string that is needed for the folder structure.

# Example
```sh
rnhc create -c compTest
```
```sh
rnhc create -c CompTest
```
- The component's folder will always be: `comp-test`.
- In the case of a given string with special characters, it will not break the operation but instead it will convert that group of special characters into a dash `-`. Like this:
```sh
rnhc create -c Comp!test
```
- The component's folder will be: `comp-test`