### PR TITLE
Feature: Add Tests for Components and Screens

### DIFF
--- a/.github/workflows/deploy-docusaurus.yml
+++ b/.github/workflows/deploy-docusaurus.yml
@@ -3,8 +3,6 @@ name: "📚 deploy-docusaurus"
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/bin/create/component/functions/create-component.js
+++ b/bin/create/component/functions/create-component.js
@@ -3,6 +3,7 @@ const {
   componentTemplateJs,
   componentTemplateTs,
   stylesTemplate,
+  testTemplate,
 } = require("../templates");
 const { config, getComponentName, getKebabCase } = require("../../../utils");
 
@@ -25,7 +26,8 @@ exports.createComponent = (
   template,
   overwrite
 ) => {
-  const { withStyles, withProps, defaultExports, componentsRoot } = config;
+  const { withStyles, withProps, withTests, defaultExports, componentsRoot } =
+    config;
   componentName = getKebabCase(componentName);
   folder = folder.includes("/")
     ? folder
@@ -43,6 +45,10 @@ exports.createComponent = (
       folder === ""
         ? `${componentsRoot}/${componentName}/styles.ts`
         : `${componentsRoot}/${folder}/${componentName}/styles.ts`;
+    const testsPath =
+      folder === ""
+        ? `${componentsRoot}/${componentName}/__tests__/index.spec.tsx`
+        : `${componentsRoot}/${folder}/${componentName}/__tests__/index.spec.tsx`;
 
     if (fs.existsSync(path) && !overwrite) {
       console.log(`${path} already exist`);
@@ -74,6 +80,14 @@ exports.createComponent = (
                 console.log(`Unable to create ${component} component styles`);
               } else {
                 console.log(`${stylesPath} created`);
+              }
+            });
+          withTests &&
+            fs.writeFile(testsPath, testTemplate(component), (err) => {
+              if (err) {
+                console.log(`Unable to create ${component} component tests`);
+              } else {
+                console.log(`${testsPath} created`);
               }
             });
         } else {
@@ -99,6 +113,14 @@ exports.createComponent = (
               console.log(`${stylesPath} created`);
             }
           });
+        withTests &&
+          fs.writeFile(testsPath, testTemplate(component), (err) => {
+            if (err) {
+              console.log(`Unable to create ${component} component tests`);
+            } else {
+              console.log(`${testsPath} created`);
+            }
+          });
       }
     }
   } else {
@@ -110,6 +132,10 @@ exports.createComponent = (
       folder === ""
         ? `${componentsRoot}/${componentName}/styles.js`
         : `${componentsRoot}/${folder}/${componentName}/styles.js`;
+    const testsPath =
+      folder === ""
+        ? `${componentsRoot}/${componentName}/__tests__/index.spec.jsx`
+        : `${componentsRoot}/${folder}/${componentName}/__tests__/index.spec.jsx`;
     if (fs.existsSync(path) && !overwrite) {
       console.log(`${path} already exist`);
     } else {
@@ -142,6 +168,14 @@ exports.createComponent = (
                 console.log(`${stylesPath} created`);
               }
             });
+          withTests &&
+            fs.writeFile(testsPath, testTemplate(component), (err) => {
+              if (err) {
+                console.log(`Unable to create ${component} component tests`);
+              } else {
+                console.log(`${testsPath} created`);
+              }
+            });
         } else {
           console.log(`.template/${template} file does not exist`);
         }
@@ -163,6 +197,14 @@ exports.createComponent = (
               console.log(`Unable to create ${component} component styles`);
             } else {
               console.log(`${stylesPath} created`);
+            }
+          });
+        withTests &&
+          fs.writeFile(testsPath, testTemplate(component), (err) => {
+            if (err) {
+              console.log(`Unable to create ${component} component tests`);
+            } else {
+              console.log(`${testsPath} created`);
             }
           });
       }

--- a/bin/create/component/functions/create-component.js
+++ b/bin/create/component/functions/create-component.js
@@ -83,13 +83,17 @@ exports.createComponent = (
               }
             });
           withTests &&
-            fs.writeFile(testsPath, testTemplate(component), (err) => {
-              if (err) {
-                console.log(`Unable to create ${component} component tests`);
-              } else {
-                console.log(`${testsPath} created`);
+            fs.writeFile(
+              testsPath,
+              testTemplate(component, defaultExports),
+              (err) => {
+                if (err) {
+                  console.log(`Unable to create ${component} component tests`);
+                } else {
+                  console.log(`${testsPath} created`);
+                }
               }
-            });
+            );
         } else {
           console.log(`.template/${template} file does not exist`);
         }
@@ -114,13 +118,17 @@ exports.createComponent = (
             }
           });
         withTests &&
-          fs.writeFile(testsPath, testTemplate(component), (err) => {
-            if (err) {
-              console.log(`Unable to create ${component} component tests`);
-            } else {
-              console.log(`${testsPath} created`);
+          fs.writeFile(
+            testsPath,
+            testTemplate(component, defaultExports),
+            (err) => {
+              if (err) {
+                console.log(`Unable to create ${component} component tests`);
+              } else {
+                console.log(`${testsPath} created`);
+              }
             }
-          });
+          );
       }
     }
   } else {
@@ -169,13 +177,17 @@ exports.createComponent = (
               }
             });
           withTests &&
-            fs.writeFile(testsPath, testTemplate(component), (err) => {
-              if (err) {
-                console.log(`Unable to create ${component} component tests`);
-              } else {
-                console.log(`${testsPath} created`);
+            fs.writeFile(
+              testsPath,
+              testTemplate(component, defaultExports),
+              (err) => {
+                if (err) {
+                  console.log(`Unable to create ${component} component tests`);
+                } else {
+                  console.log(`${testsPath} created`);
+                }
               }
-            });
+            );
         } else {
           console.log(`.template/${template} file does not exist`);
         }
@@ -200,13 +212,17 @@ exports.createComponent = (
             }
           });
         withTests &&
-          fs.writeFile(testsPath, testTemplate(component), (err) => {
-            if (err) {
-              console.log(`Unable to create ${component} component tests`);
-            } else {
-              console.log(`${testsPath} created`);
+          fs.writeFile(
+            testsPath,
+            testTemplate(component, defaultExports),
+            (err) => {
+              if (err) {
+                console.log(`Unable to create ${component} component tests`);
+              } else {
+                console.log(`${testsPath} created`);
+              }
             }
-          });
+          );
       }
     }
   }

--- a/bin/create/component/templates/component-template-js.js
+++ b/bin/create/component/templates/component-template-js.js
@@ -8,8 +8,7 @@
  * @author [Omar Belghaouti](https://github.com/Omar-Belghaouti)
  */
 exports.componentTemplateJs = (componentName, withStyles, defaultExports) => {
-  let str = `import React from "react";
-import { Text, View } from "react-native";
+  let str = `import { Text, View } from "react-native";
 `;
   if (withStyles) {
     str += `import { ${componentName}Styles } from "./styles";

--- a/bin/create/component/templates/component-template-ts.js
+++ b/bin/create/component/templates/component-template-ts.js
@@ -28,9 +28,9 @@ interface ${componentName}Props {}
   }
   if (defaultExports) {
     str += `
-const ${componentName}: FC${withProps ? `<${componentName}Props>` : ""} = (${
-      withProps ? `{}: ${componentName}Props` : ""
-    }) => {
+const ${componentName}: FC${
+      withProps ? `<${componentName}Props>` : ""
+    } = ({}) => {
   return (
     <View>
       <Text>${componentName} component created!</Text>
@@ -43,7 +43,7 @@ export default ${componentName};
     str += `
 export const ${componentName}: FC${
       withProps ? `<${componentName}Props>` : ""
-    } = (${withProps ? `{}: ${componentName}Props` : ""}) => {
+    } = ({}) => {
   return (
     <View>
       <Text>${componentName} component created!</Text>

--- a/bin/create/component/templates/index.js
+++ b/bin/create/component/templates/index.js
@@ -1,7 +1,9 @@
 const { componentTemplateJs } = require("./component-template-js");
 const { componentTemplateTs } = require("./component-template-ts");
 const { stylesTemplate } = require("./styles-template");
+const { testTemplate } = require("./test-template");
 
 exports.componentTemplateJs = componentTemplateJs;
 exports.componentTemplateTs = componentTemplateTs;
 exports.stylesTemplate = stylesTemplate;
+exports.testTemplate = testTemplate;

--- a/bin/create/component/templates/test-template.js
+++ b/bin/create/component/templates/test-template.js
@@ -2,12 +2,15 @@
  * @function testTemplate
  * @description this function returns the default test template for a component.
  * @param {string} componentName - name of component.
+ * @param {boolean} defaultExports - if the component is a default export.
  * @author [Omar Belghaouti](https://github.com/Omar-Belghaouti)
  */
-exports.testTemplate = (componentName) => {
+exports.testTemplate = (componentName, defaultExports) => {
   return `import "react-native";
 
-import { ${componentName} } from "../";
+import ${
+    defaultExports ? `${componentName}` : `{ ${componentName} }`
+  } from "../";
 import React from "react";
 import renderer from "react-test-renderer";
 

--- a/bin/create/component/templates/test-template.js
+++ b/bin/create/component/templates/test-template.js
@@ -1,0 +1,18 @@
+/**
+ * @function testTemplate
+ * @description this function returns the default test template for a component.
+ * @param {string} componentName - name of component.
+ * @author [Omar Belghaouti](https://github.com/Omar-Belghaouti)
+ */
+exports.testTemplate = (componentName) => {
+  return `import "react-native";
+
+import { ${componentName} } from "../";
+import React from "react";
+import renderer from "react-test-renderer";
+
+it("renders correctly", () => {
+  renderer.create(<${componentName} />);
+});
+`;
+};

--- a/bin/create/config/templates/default-config-template.js
+++ b/bin/create/config/templates/default-config-template.js
@@ -8,6 +8,7 @@ exports.defaultConfigTemplate = () => {
   "withStyles": true,
   "withFunctions": true,
   "withProps": true,
+  "withTest": true,
   "defaultExports": true,
   "componentsRoot": "./src/components",
   "screensRoot": "./src/screens",

--- a/bin/create/screen/functions/create-screen.js
+++ b/bin/create/screen/functions/create-screen.js
@@ -5,6 +5,7 @@ const {
   screenFunctionTemplateJs,
   screenFunctionTemplateTs,
   stylesTemplate,
+  testTemplate,
 } = require("../templates");
 const { config, getComponentName, getKebabCase } = require("../../../utils");
 
@@ -20,8 +21,14 @@ const { config, getComponentName, getKebabCase } = require("../../../utils");
  * @author [Omar Belghaouti](https://github.com/Omar-Belghaouti)
  */
 exports.createScreen = (screenName, js, ts, folder, template, overwrite) => {
-  const { withStyles, withFunctions, withProps, defaultExports, screensRoot } =
-    config;
+  const {
+    withStyles,
+    withFunctions,
+    withProps,
+    withTests,
+    defaultExports,
+    screensRoot,
+  } = config;
   screenName = getKebabCase(screenName);
   folder = folder.includes("/")
     ? folder
@@ -117,6 +124,17 @@ exports.createScreen = (screenName, js, ts, folder, template, overwrite) => {
             console.log(`${path}styles.ts created`);
           }
         });
+      withTests &&
+        fs.writeFile(
+          `${path}__tests__/index.spec.tsx`,
+          testTemplate(screen, defaultExports),
+          (err) => {
+            if (err) {
+              console.log(`Unable to create ${screen} screen tests`);
+            }
+            console.log(`${path}__tests__/index.spec.tsx created`);
+          }
+        );
     } else {
       // check if template file exist
       if (template !== "") {
@@ -185,6 +203,17 @@ exports.createScreen = (screenName, js, ts, folder, template, overwrite) => {
             console.log(`${path}styles.js created`);
           }
         });
+      withTests &&
+        fs.writeFile(
+          `${path}__tests__/index.spec.jsx`,
+          testTemplate(screen, defaultExports),
+          (err) => {
+            if (err) {
+              console.log(`Unable to create ${screen} screen tests`);
+            }
+            console.log(`${path}__tests__/index.spec.jsx created`);
+          }
+        );
     }
   }
 };

--- a/bin/create/screen/templates/index.js
+++ b/bin/create/screen/templates/index.js
@@ -3,9 +3,11 @@ const { screenTemplateTs } = require("./screen-template-ts");
 const { screenFunctionTemplateJs } = require("./screen-function-template-js");
 const { screenFunctionTemplateTs } = require("./screen-function-template-ts");
 const { stylesTemplate } = require("./styles-template");
+const { testTemplate } = require("./test-template");
 
 exports.screenTemplateJs = screenTemplateJs;
 exports.screenTemplateTs = screenTemplateTs;
 exports.screenFunctionTemplateJs = screenFunctionTemplateJs;
 exports.screenFunctionTemplateTs = screenFunctionTemplateTs;
 exports.stylesTemplate = stylesTemplate;
+exports.testTemplate = testTemplate;

--- a/bin/create/screen/templates/screen-template-js.js
+++ b/bin/create/screen/templates/screen-template-js.js
@@ -14,8 +14,7 @@ exports.screenTemplateJs = (
   withStyles,
   defaultExports
 ) => {
-  let str = `import React from "react";
-import { Text, View } from "react-native";
+  let str = `import { Text, View } from "react-native";
 `;
   if (withFunctions) {
     str += `import {} from "./functions";

--- a/bin/create/screen/templates/screen-template-ts.js
+++ b/bin/create/screen/templates/screen-template-ts.js
@@ -16,7 +16,7 @@ exports.screenTemplateTs = (
   defaultExports,
   withProps
 ) => {
-  let str = `import React, { FC } from "react";
+  let str = `import { FC } from "react";
 import { Text, View } from "react-native";
 `;
   if (withFunctions) {
@@ -36,7 +36,7 @@ interface ${screenName}ScreenProps {}
     str += `
 const ${screenName}Screen: FC${
       withProps ? `<${screenName}ScreenProps>` : ""
-    } = (${withProps ? `{}: ${screenName}ScreenProps` : ""}) => {
+    } = ({}) => {
   return (
     <View>
       <Text>${screenName} screen created!</Text>
@@ -49,7 +49,7 @@ export default ${screenName}Screen;
     str += `
 export const ${screenName}Screen: FC${
       withProps ? `<${screenName}ScreenProps>` : ""
-    } = (${withProps ? `{}: ${screenName}ScreenProps` : ""}) => {
+    } = ({}) => {
   return (
     <View>
       <Text>${screenName} screen created!</Text>

--- a/bin/create/screen/templates/test-template.js
+++ b/bin/create/screen/templates/test-template.js
@@ -1,0 +1,21 @@
+/**
+ * @function testTemplate
+ * @description this function returns the default test template for a screen.
+ * @param {string} screenName - name of screen.
+ * @param {boolean} defaultExports - if the screen is a default export.
+ * @author [Omar Belghaouti](https://github.com/Omar-Belghaouti)
+ */
+exports.testTemplate = (screenName, defaultExports) => {
+  return `import "react-native";
+
+import ${
+    defaultExports ? `${screenName}Screen` : `{ ${screenName}Screen }`
+  } from "../";
+import React from "react";
+import renderer from "react-test-renderer";
+
+it("renders correctly", () => {
+  renderer.create(<${screenName}Screen />);
+});
+`;
+};

--- a/bin/utils/configs.js
+++ b/bin/utils/configs.js
@@ -1,9 +1,9 @@
 let config = {
-  withStyles: true, // if true, create styles file for components and pages, if false, don't create styles file
-  withFunctions: true, // if true, create functions folder for pages, if false, don't create functions folder
-  withProps: true, // if true, create props interface for components and pages (in TS only), if false, don't create props interface
-  withTest: true, // if true, create test file for components and pages, if false, don't create test file
-  defaultExports: true, // if true, create default export for components and pages, if false, create named export for components and pages
+  withStyles: true, // if true, create styles file for components and screens, if false, don't create styles file
+  withFunctions: true, // if true, create functions folder for screens, if false, don't create functions folder
+  withProps: true, // if true, create props interface for components and screens (in TS only), if false, don't create props interface
+  withTests: true, // if true, create test file for components and screens, if false, don't create test file
+  defaultExports: true, // if true, create default export for components and screens, if false, create named export for components and screens
   componentsRoot: "./src/components", // path to components folder
   screensRoot: "./src/screens", // path to screens folder
   reduxRoot: "./src/redux", // path to redux folder

--- a/bin/utils/configs.js
+++ b/bin/utils/configs.js
@@ -2,6 +2,7 @@ let config = {
   withStyles: true, // if true, create styles file for components and pages, if false, don't create styles file
   withFunctions: true, // if true, create functions folder for pages, if false, don't create functions folder
   withProps: true, // if true, create props interface for components and pages (in TS only), if false, don't create props interface
+  withTest: true, // if true, create test file for components and pages, if false, don't create test file
   defaultExports: true, // if true, create default export for components and pages, if false, create named export for components and pages
   componentsRoot: "./src/components", // path to components folder
   screensRoot: "./src/screens", // path to screens folder

--- a/bin/utils/load-config.js
+++ b/bin/utils/load-config.js
@@ -14,6 +14,7 @@ exports.loadConfig = () => {
       withStyles,
       withFunctions,
       withProps,
+      withTest,
       defaultExports,
       componentsRoot,
       screensRoot,
@@ -24,6 +25,7 @@ exports.loadConfig = () => {
     config.withFunctions =
       typeof withFunctions === "boolean" ? withFunctions : true;
     config.withProps = typeof withProps === "boolean" ? withProps : true;
+    config.withTest = typeof withTest === "boolean" ? withTest : true;
     config.defaultExports =
       typeof defaultExports === "boolean" ? defaultExports : true;
     config.componentsRoot =

--- a/bin/utils/load-config.js
+++ b/bin/utils/load-config.js
@@ -14,7 +14,7 @@ exports.loadConfig = () => {
       withStyles,
       withFunctions,
       withProps,
-      withTest,
+      withTests,
       defaultExports,
       componentsRoot,
       screensRoot,
@@ -25,7 +25,7 @@ exports.loadConfig = () => {
     config.withFunctions =
       typeof withFunctions === "boolean" ? withFunctions : true;
     config.withProps = typeof withProps === "boolean" ? withProps : true;
-    config.withTest = typeof withTest === "boolean" ? withTest : true;
+    config.withTests = typeof withTests === "boolean" ? withTests : true;
     config.defaultExports =
       typeof defaultExports === "boolean" ? defaultExports : true;
     config.componentsRoot =

--- a/tests/combine.spec.js
+++ b/tests/combine.spec.js
@@ -27,12 +27,18 @@ describe("combine components tests", () => {
       expect(fs.existsSync("./src/components/folder/test1/styles.ts")).toBe(
         true
       );
+      expect(
+        fs.existsSync("./src/components/folder/test1/__tests__/index.spec.tsx")
+      ).toBe(true);
       expect(fs.existsSync("./src/components/folder/test2/index.tsx")).toBe(
         true
       );
       expect(fs.existsSync("./src/components/folder/test2/styles.ts")).toBe(
         true
       );
+      expect(
+        fs.existsSync("./src/components/folder/test2/__tests__/index.spec.tsx")
+      ).toBe(true);
       deleteComponents(["test1", "test2"], "folder");
       await sleep(100);
     } catch (err) {
@@ -78,10 +84,16 @@ describe("combine screens tests", () => {
       expect(
         fs.existsSync("./src/screens/folder/test1/functions/index.ts")
       ).toBe(true);
+      expect(
+        fs.existsSync("./src/screens/folder/test1/__tests__/index.spec.tsx")
+      ).toBe(true);
       expect(fs.existsSync("./src/screens/folder/test2/index.tsx")).toBe(true);
       expect(fs.existsSync("./src/screens/folder/test2/styles.ts")).toBe(true);
       expect(
         fs.existsSync("./src/screens/folder/test2/functions/index.ts")
+      ).toBe(true);
+      expect(
+        fs.existsSync("./src/screens/folder/test2/__tests__/index.spec.tsx")
       ).toBe(true);
       deleteScreens(["test1", "test2"], "folder");
       await sleep(100);

--- a/tests/create.spec.js
+++ b/tests/create.spec.js
@@ -34,6 +34,9 @@ describe("create component tests", () => {
       await sleep(100);
       expect(fs.existsSync("./src/components/test1/index.tsx")).toBe(true);
       expect(fs.existsSync("./src/components/test1/styles.ts")).toBe(true);
+      expect(
+        fs.existsSync("./src/components/test1/__tests__/index.spec.tsx")
+      ).toBe(true);
       deleteComponents(["test1"], "");
       await sleep(100);
     } catch (err) {
@@ -47,6 +50,9 @@ describe("create component tests", () => {
       await sleep(100);
       expect(fs.existsSync("./src/components/test2/index.jsx")).toBe(true);
       expect(fs.existsSync("./src/components/test2/styles.js")).toBe(true);
+      expect(
+        fs.existsSync("./src/components/test2/__tests__/index.spec.jsx")
+      ).toBe(true);
       deleteComponents(["test2"], "");
       await sleep(100);
     } catch (err) {
@@ -64,6 +70,9 @@ describe("create component tests", () => {
       expect(fs.existsSync("./src/components/folder/test3/styles.ts")).toBe(
         true
       );
+      expect(
+        fs.existsSync("./src/components/folder/test3/__tests__/index.spec.tsx")
+      ).toBe(true);
       deleteComponents(["test3"], "folder");
       await sleep(100);
     } catch (err) {
@@ -81,6 +90,9 @@ describe("create component tests", () => {
       expect(fs.existsSync("./src/components/folder/test4/styles.js")).toBe(
         true
       );
+      expect(
+        fs.existsSync("./src/components/folder/test4/__tests__/index.spec.jsx")
+      ).toBe(true);
       deleteComponents(["test4"], "folder");
       await sleep(100);
     } catch (err) {
@@ -94,6 +106,9 @@ describe("create component tests", () => {
       await sleep(100);
       expect(fs.existsSync("./src/components/test5/index.tsx")).toBe(true);
       expect(fs.existsSync("./src/components/test5/styles.ts")).toBe(true);
+      expect(
+        fs.existsSync("./src/components/test5/__tests__/index.spec.tsx")
+      ).toBe(true);
       deleteComponents(["test5"], "");
       await sleep(100);
     } catch (err) {
@@ -111,6 +126,9 @@ describe("create component tests", () => {
       expect(fs.existsSync("./src/components/folder/test6/styles.ts")).toBe(
         true
       );
+      expect(
+        fs.existsSync("./src/components/folder/test6/__tests__/index.spec.tsx")
+      ).toBe(true);
       deleteComponents(["test6"], "folder");
       await sleep(100);
     } catch (err) {
@@ -133,6 +151,9 @@ describe("create screen tests", () => {
       expect(fs.existsSync("./src/screens/test/index.tsx")).toBe(true);
       expect(fs.existsSync("./src/screens/test/styles.ts")).toBe(true);
       expect(fs.existsSync("./src/screens/test/functions/index.ts")).toBe(true);
+      expect(fs.existsSync("./src/screens/test/__tests__/index.spec.tsx")).toBe(
+        true
+      );
       deleteScreens(["test"], "");
       await sleep(100);
     } catch (err) {
@@ -147,6 +168,9 @@ describe("create screen tests", () => {
       expect(fs.existsSync("./src/screens/test/index.jsx")).toBe(true);
       expect(fs.existsSync("./src/screens/test/styles.js")).toBe(true);
       expect(fs.existsSync("./src/screens/test/functions/index.js")).toBe(true);
+      expect(fs.existsSync("./src/screens/test/__tests__/index.spec.jsx")).toBe(
+        true
+      );
       deleteScreens(["test"], "");
       await sleep(100);
     } catch (err) {
@@ -162,6 +186,9 @@ describe("create screen tests", () => {
       expect(fs.existsSync("./src/screens/folder/test/styles.ts")).toBe(true);
       expect(
         fs.existsSync("./src/screens/folder/test/functions/index.ts")
+      ).toBe(true);
+      expect(
+        fs.existsSync("./src/screens/folder/test/__tests__/index.spec.tsx")
       ).toBe(true);
       deleteScreens(["test"], "folder");
       await sleep(100);
@@ -179,6 +206,9 @@ describe("create screen tests", () => {
       expect(
         fs.existsSync("./src/screens/folder/test/functions/index.js")
       ).toBe(true);
+      expect(
+        fs.existsSync("./src/screens/folder/test/__tests__/index.spec.jsx")
+      ).toBe(true);
       deleteScreens(["test"], "folder");
       await sleep(100);
     } catch (err) {
@@ -193,6 +223,9 @@ describe("create screen tests", () => {
       expect(fs.existsSync("./src/screens/test/index.tsx")).toBe(true);
       expect(fs.existsSync("./src/screens/test/styles.ts")).toBe(true);
       expect(fs.existsSync("./src/screens/test/functions/index.ts")).toBe(true);
+      expect(fs.existsSync("./src/screens/test/__tests__/index.spec.tsx")).toBe(
+        true
+      );
       deleteScreens(["test"], "");
       await sleep(100);
     } catch (err) {
@@ -208,6 +241,9 @@ describe("create screen tests", () => {
       expect(fs.existsSync("./src/screens/folder/test/styles.ts")).toBe(true);
       expect(
         fs.existsSync("./src/screens/folder/test/functions/index.ts")
+      ).toBe(true);
+      expect(
+        fs.existsSync("./src/screens/folder/test/__tests__/index.spec.tsx")
       ).toBe(true);
       deleteScreens(["test"], "folder");
       await sleep(100);

--- a/tests/delete.spec.js
+++ b/tests/delete.spec.js
@@ -34,10 +34,16 @@ describe("delete component tests", () => {
       await sleep(100);
       expect(fs.existsSync("./src/components/del-test/index.tsx")).toBe(true);
       expect(fs.existsSync("./src/components/del-test/styles.ts")).toBe(true);
+      expect(
+        fs.existsSync("./src/components/del-test/__tests__/index.spec.tsx")
+      ).toBe(true);
       deleteComponents(["del-test"], "");
       await sleep(100);
       expect(fs.existsSync("./src/components/del-test/index.tsx")).toBe(false);
       expect(fs.existsSync("./src/components/del-test/styles.ts")).toBe(false);
+      expect(
+        fs.existsSync("./src/components/del-test/__tests__/index.spec.tsx")
+      ).toBe(false);
     } catch (err) {
       fail(err);
     }
@@ -47,10 +53,16 @@ describe("delete component tests", () => {
     try {
       expect(fs.existsSync("./src/components/del-test/index.tsx")).toBe(false);
       expect(fs.existsSync("./src/components/del-test/styles.ts")).toBe(false);
+      expect(
+        fs.existsSync("./src/components/del-test/__tests__/index.spec.tsx")
+      ).toBe(false);
       deleteComponents(["del-test"], "");
       await sleep(100);
       expect(fs.existsSync("./src/components/del-test/index.tsx")).toBe(false);
       expect(fs.existsSync("./src/components/del-test/styles.ts")).toBe(false);
+      expect(
+        fs.existsSync("./src/components/del-test/__tests__/index.spec.tsx")
+      ).toBe(false);
     } catch (err) {
       fail(err);
     }
@@ -77,6 +89,9 @@ describe("delete screen tests", () => {
       expect(fs.existsSync("./src/screens/del-test/functions/index.ts")).toBe(
         true
       );
+      expect(
+        fs.existsSync("./src/screens/del-test/__tests__/index.spec.tsx")
+      ).toBe(true);
       deleteScreens(["del-test"], "");
       await sleep(100);
       expect(fs.existsSync("./src/screens/del-test/index.tsx")).toBe(false);
@@ -84,6 +99,9 @@ describe("delete screen tests", () => {
       expect(fs.existsSync("./src/screens/del-test/functions/index.ts")).toBe(
         false
       );
+      expect(
+        fs.existsSync("./src/screens/del-test/__tests__/index.spec.tsx")
+      ).toBe(false);
     } catch (err) {
       fail(err);
     }
@@ -98,6 +116,9 @@ describe("delete screen tests", () => {
       expect(fs.existsSync("./src/screens/del-test/functions/index.ts")).toBe(
         false
       );
+      expect(
+        fs.existsSync("./src/screens/del-test/__tests__/index.spec.tsx")
+      ).toBe(false);
       deleteScreens(["del-test"], "");
       await sleep(100);
       expect(fs.existsSync("./src/screens/del-test/index.tsx")).toBe(false);
@@ -105,6 +126,9 @@ describe("delete screen tests", () => {
       expect(fs.existsSync("./src/screens/del-test/functions/index.ts")).toBe(
         false
       );
+      expect(
+        fs.existsSync("./src/screens/del-test/__tests__/index.spec.tsx")
+      ).toBe(false);
     } catch (err) {
       fail(err);
     }


### PR DESCRIPTION
This PR is dedicated to add a feature that gives the option to create test files when creating components and screens.

- It can be set in the `rnhc.config.json` file, the default will be true.

# TODOs
- [x] create components with tests.
- [x] create screens withs tests.
- [x] add checking the existence of created test files in test cases.
 